### PR TITLE
Don't rely on ssreflect setoid rewrite bug (coq/coq#13882)

### DIFF
--- a/iris/algebra/mlist.v
+++ b/iris/algebra/mlist.v
@@ -223,7 +223,7 @@ Lemma fmlist_lb_agree γ l1 l2 :
   fmlist_lb γ l1 -∗ fmlist_lb γ l2 -∗ ⌜ l1 `prefix_of` l2 ∨ l2 `prefix_of` l1⌝.
 Proof.
   iIntros "Hγ1 Hγ2". iDestruct (own_valid_2 with "Hγ1 Hγ2") as %Hval.
-  rewrite -auth_frag_op auth_frag_valid in Hval * => Hval.
+  revert Hval; rewrite -auth_frag_op auth_frag_valid => Hval.
   iPureIntro. by apply mlist_valid_op in Hval.
 Qed.
 

--- a/iris/base_logic/lib/wsat.v
+++ b/iris/base_logic/lib/wsat.v
@@ -243,7 +243,7 @@ Proof.
   intros n l1 l2 Hd.
   rewrite /invariant_unfold.
   specialize (vec_to_list_same_length l1 l2) => Hlen.
-  rewrite dist_later_vec_to_list in Hd *.
+  revert Hd; rewrite dist_later_vec_to_list.
   remember (vec_to_list l1) as l1' eqn:Heq1.
   remember (vec_to_list l2) as l2' eqn:Heq2.
   rewrite -Heq1 -Heq2.


### PR DESCRIPTION
Before the mentioned Coq PR, "rewrite foo in H *" with ssreflect
rewrite and a setoid equality would leave the goal with H reverted.

Instead we manually revert H and don't use "in".